### PR TITLE
Use `"k8s.io/client-go/tools/clientcmd".PathOptions` to find kubeconfig

### DIFF
--- a/infrastructure/config/env.go
+++ b/infrastructure/config/env.go
@@ -11,7 +11,6 @@ import (
 type Environment struct {
 	Port           string
 	HeaderName     string
-	KubeConfig     string
 	Timeout        time.Duration
 	TrustedProxies []string
 }
@@ -23,7 +22,6 @@ func Get() (Environment, error) {
 	var trustedProxies string
 
 	for k, v := range map[string]*string{
-		"KUBECONFIG":      &env.KubeConfig,
 		"TIMEOUT_MS":      &timeout,
 		"TRUSTED_PROXIES": &trustedProxies,
 	} {

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/chitoku-k/healthcheck-k8s/application/server"
 	"github.com/chitoku-k/healthcheck-k8s/infrastructure/config"
@@ -18,8 +19,11 @@ func main() {
 	}
 
 	var config *rest.Config
-	if env.KubeConfig != "" {
-		config, err = clientcmd.BuildConfigFromFlags("", env.KubeConfig)
+	kubeconfigPath := clientcmd.NewDefaultPathOptions().GetDefaultFilename()
+
+	_, err = os.Stat(kubeconfigPath)
+	if !os.IsNotExist(err) {
+		config, err = clientcmd.BuildConfigFromFlags("", kubeconfigPath)
 	} else {
 		config, err = rest.InClusterConfig()
 	}


### PR DESCRIPTION
The environment variable `KUBECONFIG` is still respected when it exists.