### PR TITLE
Embed git tag version into binary for User-Agent

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,6 +17,10 @@ jobs:
         uses: actions/checkout@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+      - name: Get version
+        id: version
+        run: |
+          echo version="$(git describe --tags --always --dirty)" >> "$GITHUB_OUTPUT"
       - name: Build
         uses: docker/build-push-action@v4
         with:
@@ -25,6 +29,8 @@ jobs:
           cache-to: type=gha,mode=max
           load: true
           tags: container.chitoku.jp/chitoku-k/healthcheck-k8s
+          args: |
+            VERSION=${{ steps.version.outputs.version }}
       - name: Set up ID token
         uses: actions/github-script@v6
         id: id-token

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,10 @@ COPY go.mod go.sum /usr/src/
 RUN --mount=type=cache,target=/go \
     go mod download
 COPY . /usr/src/
+ARG VERSION=v0.0.0-dev
 RUN --mount=type=cache,target=/go \
     --mount=type=cache,target=/root/.cache/go-build \
-    CGO_ENABLED=0 go build -ldflags='-s -w'
+    CGO_ENABLED=0 go build -ldflags="-s -w -X main.version=$VERSION"
 
 FROM scratch
 ENV GIN_MODE release

--- a/main.go
+++ b/main.go
@@ -14,7 +14,11 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-var signals = []os.Signal{os.Interrupt}
+var (
+	signals = []os.Signal{os.Interrupt}
+	name    = "healthcheck-k8s"
+	version = "v0.0.0-dev"
+)
 
 func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), signals...)
@@ -40,6 +44,8 @@ func main() {
 	}
 
 	config.Timeout = env.Timeout
+	config.UserAgent = name + "/" + version
+
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		panic(fmt.Errorf("failed to initialize clientset: %w", err))


### PR DESCRIPTION
This PR lets every request from healthcheck-k8s to kube-apiserver have well-formatted User-Agent header.

```
User-Agent: healthcheck-k8s/v0.0.0 (linux/amd64) kubernetes/$Format
```
↓
```
User-Agent: healthcheck-k8s/v1.6.0
```