### PR TITLE
Enable auth plugins from client-go on development builds

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -30,6 +30,7 @@ jobs:
           load: true
           tags: container.chitoku.jp/chitoku-k/healthcheck-k8s
           args: |
+            TAGS=authless
             VERSION=${{ steps.version.outputs.version }}
       - name: Set up ID token
         uses: actions/github-script@v6

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,11 @@ COPY go.mod go.sum /usr/src/
 RUN --mount=type=cache,target=/go \
     go mod download
 COPY . /usr/src/
+ARG TAGS
 ARG VERSION=v0.0.0-dev
 RUN --mount=type=cache,target=/go \
     --mount=type=cache,target=/root/.cache/go-build \
-    CGO_ENABLED=0 go build -ldflags="-s -w -X main.version=$VERSION"
+    CGO_ENABLED=0 go build -tags="$TAGS" -ldflags="-s -w -X main.version=$VERSION"
 
 FROM scratch
 ENV GIN_MODE release

--- a/kubernetes_auth.go
+++ b/kubernetes_auth.go
@@ -1,0 +1,6 @@
+//go:build !authless
+
+package main
+
+// Enable auth plugins from client-go such as "oidc".
+import _ "k8s.io/client-go/plugin/pkg/client/auth"


### PR DESCRIPTION
This PR enables `auth-provider` in kubeconfig that are disabled by default on development builds. It will not be included in production builds so as not to bloat the binary size.