### PR TITLE
Use `k8s.io/client-go/informers` to list/watch nodes

### DIFF
--- a/infrastructure/k8s/service.go
+++ b/infrastructure/k8s/service.go
@@ -8,22 +8,21 @@ import (
 
 	"github.com/chitoku-k/healthcheck-k8s/service"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
+	listercorev1 "k8s.io/client-go/listers/core/v1"
 )
 
 type healthCheckService struct {
-	Clientset kubernetes.Interface
+	nodeLister listercorev1.NodeLister
 }
 
-func NewHealthCheckService(clientset kubernetes.Interface) service.HealthCheck {
+func NewHealthCheckService(nodeLister listercorev1.NodeLister) service.HealthCheck {
 	return &healthCheckService{
-		Clientset: clientset,
+		nodeLister: nodeLister,
 	}
 }
 
 func (s *healthCheckService) Do(ctx context.Context, nodeName string) (bool, error) {
-	node, err := s.Clientset.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+	node, err := s.nodeLister.Get(nodeName)
 	if apierrors.IsNotFound(err) {
 		return false, service.NewNotFoundError(err)
 	}

--- a/main.go
+++ b/main.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"time"
 
 	"github.com/chitoku-k/healthcheck-k8s/application/server"
 	"github.com/chitoku-k/healthcheck-k8s/infrastructure/config"
 	"github.com/chitoku-k/healthcheck-k8s/infrastructure/k8s"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -51,10 +53,38 @@ func main() {
 		panic(fmt.Errorf("failed to initialize clientset: %w", err))
 	}
 
-	healthCheck := k8s.NewHealthCheckService(clientset)
+	informerFactory := informers.NewSharedInformerFactory(clientset, 0)
+	nodeLister := informerFactory.Core().V1().Nodes().Lister()
+
+	informerFactory.Start(ctx.Done())
+
+	err = waitForCacheSync(ctx, env.Timeout, informerFactory)
+	if err != nil {
+		panic(fmt.Errorf("failed to initialize node cache: %w", err))
+	}
+
+	healthCheck := k8s.NewHealthCheckService(nodeLister)
 	engine := server.NewEngine(env.Port, env.HeaderName, env.TrustedProxies, healthCheck)
 	err = engine.Start(ctx)
 	if err != nil {
 		panic(fmt.Errorf("failed to start web server: %v", err))
 	}
+}
+
+func waitForCacheSync(ctx context.Context, timeout time.Duration, factory informers.SharedInformerFactory) error {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	for typ, done := range factory.WaitForCacheSync(ctx.Done()) {
+		if !done {
+			select {
+			case <-ctx.Done():
+				return fmt.Errorf("failed to sync %v: %v", typ, ctx.Err())
+			default:
+				return fmt.Errorf("failed to sync %v", typ)
+			}
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
This PR uses list/watch API to observe Node resources instead of calling get API to retrieve Node information every time it receives a health check request.